### PR TITLE
import errno for errno.EEXIST

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import numpy as np
 from PIL import Image


### PR DESCRIPTION
__errno.EEXIST__ is used on line 68 but __errno__ is never imported.