### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import json
 import cPickle
@@ -40,11 +41,11 @@ class Dictionary(object):
 
     def dump_to_file(self, path):
         cPickle.dump([self.word2idx, self.idx2word], open(path, 'wb'))
-        print 'dictionary dumped to %s' % path
+        print('dictionary dumped to %s' % path)
 
     @classmethod
     def load_from_file(cls, path):
-        print 'loading dictionary from %s' % path
+        print('loading dictionary from %s' % path)
         word2idx, idx2word = cPickle.load(open(path, 'rb'))
         d = cls(word2idx, idx2word)
         return d
@@ -112,7 +113,7 @@ class VQAFeatureDataset(Dataset):
 
         self.img_id2idx = cPickle.load(
             open(os.path.join(dataroot, '%s36_imgid2idx.pkl' % name)))
-        print 'loading features from h5 file'
+        print('loading features from h5 file')
         h5_path = os.path.join(dataroot, '%s36.hdf5' % name)
         with h5py.File(h5_path, 'r') as hf:
             self.features = np.array(hf.get('image_features'))

--- a/fc.py
+++ b/fc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import torch.nn as nn
 from torch.nn.utils.weight_norm import weight_norm
 
@@ -25,8 +26,8 @@ class FCNet(nn.Module):
 
 if __name__ == '__main__':
     fc1 = FCNet([10, 20, 10])
-    print fc1
+    print(fc1)
 
-    print '============'
+    print('============')
     fc2 = FCNet([10, 20])
-    print fc2
+    print(fc2)

--- a/tools/compute_softscore.py
+++ b/tools/compute_softscore.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import json
@@ -145,8 +146,8 @@ def filter_answers(answers_dset, min_occurence):
         if len(occurence[answer]) < min_occurence:
             occurence.pop(answer)
 
-    print 'Num of answers that appear >= %d times: %d' % (
-        min_occurence, len(occurence))
+    print('Num of answers that appear >= %d times: %d' % (
+        min_occurence, len(occurence)))
     return occurence
 
 

--- a/tools/create_dictionary.py
+++ b/tools/create_dictionary.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import json
@@ -28,7 +29,7 @@ def create_glove_embedding_init(idx2word, glove_file):
     with open(glove_file, 'r') as f:
         entries = f.readlines()
     emb_dim = len(entries[0].split(' ')) - 1
-    print 'embedding dim is %d' % emb_dim
+    print('embedding dim is %d' % emb_dim)
     weights = np.zeros((len(idx2word), emb_dim), dtype=np.float32)
 
     for entry in entries:

--- a/tools/detection_features_converter.py
+++ b/tools/detection_features_converter.py
@@ -8,6 +8,7 @@ Hierarchy of HDF5 file:
 { 'image_features': num_images x num_boxes x 2048 array of features
   'image_bb': num_images x num_boxes x 4 array of bounding boxes }
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -69,7 +70,7 @@ if __name__ == '__main__':
     train_counter = 0
     val_counter = 0
 
-    print "reading tsv..."
+    print("reading tsv...")
     with open(infile, "r+b") as tsv_in_file:
         reader = csv.DictReader(tsv_in_file, delimiter='\t', fieldnames=FIELDNAMES)
         for item in reader:
@@ -126,13 +127,13 @@ if __name__ == '__main__':
                 assert False, 'Unknown image id: %d' % image_id
 
     if len(train_imgids) != 0:
-        print 'Warning: train_image_ids is not empty'
+        print('Warning: train_image_ids is not empty')
 
     if len(val_imgids) != 0:
-        print 'Warning: val_image_ids is not empty'
+        print('Warning: val_image_ids is not empty')
 
     cPickle.dump(train_indices, open(train_indices_file, 'wb'))
     cPickle.dump(val_indices, open(val_indices_file, 'wb'))
     h_train.close()
     h_val.close()
-    print "done!"
+    print("done!")

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+import errno
 import os
 import numpy as np
 from PIL import Image
@@ -49,7 +51,7 @@ def weights_init(m):
         m.weight.data.normal_(1.0, 0.02)
         m.bias.data.fill_(0)
     else:
-        print '%s is not initialized.' % cname
+        print('%s is not initialized.' % cname)
 
 
 def init_net(net, net_file):
@@ -94,4 +96,4 @@ class Logger(object):
     def write(self, msg):
         self.log_file.write(msg + '\n')
         self.log_file.flush()
-        print msg
+        print(msg)


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There may be more changes required to complete a port to Python 3 but this is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
