### PR TITLE
fix vqa score computation

### DIFF
--- a/tools/compute_softscore.py
+++ b/tools/compute_softscore.py
@@ -78,16 +78,7 @@ punct = [';', r"/", '[', ']', '"', '{', '}',
 
 
 def get_score(occurences):
-    if occurences == 0:
-        return 0
-    elif occurences == 1:
-        return 0.3
-    elif occurences == 2:
-        return 0.6
-    elif occurences == 3:
-        return 0.9
-    else:
-        return 1
+    return min(1., occurences/3.)
 
 
 def process_punctuation(inText):


### PR DESCRIPTION
It looks like the VQA score isn't quite what's specified as the [VQA evaluation metric](http://www.visualqa.org/evaluation.html). It underestimates the actual VQA score a bit. This pull request fixes that. Note that it requires re-caching the labels by running `tools/compute_softscore.py` again. When I ran this on some models I've been testing most scores went up by about 0.9.